### PR TITLE
Fix admin login redirect issue

### DIFF
--- a/src/pages/api/auth/[...nextauth].js
+++ b/src/pages/api/auth/[...nextauth].js
@@ -67,6 +67,7 @@ export default NextAuth({
       if (user) {
         token.gallerySlug = user.gallerySlug
         token.galleryTitle = user.galleryTitle
+        token.type = user.type
       }
       return token
     },
@@ -74,12 +75,9 @@ export default NextAuth({
       if (token) {
         session.user.gallerySlug = token.gallerySlug
         session.user.galleryTitle = token.galleryTitle
+        session.user.type = token.type
       }
       return session
     }
-  },
-  pages: {
-    signIn: '/gallery/login',
-    error: '/gallery/login'
   }
 })


### PR DESCRIPTION
Problem: Admin login was redirecting to gallery login page
- Removed global signIn redirect from NextAuth config
- Added user type to session callbacks
- Now admin and gallery logins work independently

Admin login should now stay on admin flow instead of redirecting to gallery.