### PR TITLE
Fix Galleries navigation button visibility issue

### DIFF
--- a/src/pages/header.tsx
+++ b/src/pages/header.tsx
@@ -130,8 +130,9 @@ export default function Header() {
         </button>
       </nav>
       {/* Mobile Menu Dropdown */}
-      {isMenuOpen && (
-        <ul className="md:hidden bg-[var(--background)] border-t border-[var(--secondary)]/20 absolute left-0 right-0 top-full z-50 shadow-md">
+      <ul className={`md:hidden bg-[var(--background)] border-t border-[var(--secondary)]/20 absolute left-0 right-0 top-full z-50 shadow-md transition-all duration-200 ${
+        isMenuOpen ? 'opacity-100 visible' : 'opacity-0 invisible pointer-events-none'
+      }`}>
           <li>
             <Link
               href="/"
@@ -195,8 +196,7 @@ export default function Header() {
               Client Gallery Access
             </Link>
           </li>
-        </ul>
-      )}
+      </ul>
     </header>
   );
 }


### PR DESCRIPTION
- Replace conditional rendering with CSS visibility classes for mobile menu
- Ensures Galleries link is always present in DOM but hidden when menu is closed
- Fixes hydration mismatch that was preventing Galleries button from appearing
- Mobile menu now uses opacity/visibility transitions instead of conditional rendering

🤖 Generated with [Claude Code](https://claude.ai/code)